### PR TITLE
feat(openmemory): default container Qdrant URL

### DIFF
--- a/openmemory/README.md
+++ b/openmemory/README.md
@@ -64,13 +64,16 @@ You can do this in one of the following ways:
   ```
 - #### Example `/api/.env`
 
+When deploying in containers, **you must set `QDRANT_URL`** to the internal service URL (e.g., `http://mem0_store:6333`).
+
 ```env
 # 下面是必要的配置
 NEO4J_URI=neo4j://localhost:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=mem0graph
 
-QDRANT_URL=http://localhost:6333
+# When running in Docker, point QDRANT_URL to the internal service
+QDRANT_URL=http://mem0_store:6333
 
 OPENAI_API_KEY=sk-3762ca6276b7405c9e8271c5d88e0758
 OPENAI_BASE_URL=https://api.deepseek.com

--- a/openmemory/READMECN.md
+++ b/openmemory/READMECN.md
@@ -60,10 +60,12 @@ curl -sL https://raw.githubusercontent.com/mem0ai/mem0/main/openmemory/run.sh | 
  - **使用Makefile**（如果支持）：
    运行：
  
-  ```bash
+```bash
   make env
   ```
 - #### 示例 `/api/.env`
+
+在容器环境中部署时，**必须设置 `QDRANT_URL`** 为内部服务地址（例如 `http://mem0_store:6333`）。
 
 ```env
 # 下面是必要的配置
@@ -71,7 +73,8 @@ NEO4J_URI=neo4j://localhost:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=mem0graph
 
-QDRANT_URL=http://localhost:6333
+# 容器部署时请将 QDRANT_URL 指向服务名
+QDRANT_URL=http://mem0_store:6333
 
 OPENAI_API_KEY=sk-3762ca6276b7405c9e8271c5d88e0758
 OPENAI_BASE_URL=https://api.deepseek.com

--- a/openmemory/api/.env.example
+++ b/openmemory/api/.env.example
@@ -3,7 +3,8 @@ NEO4J_URI=neo4j://localhost:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=mem0graph
 
-QDRANT_URL=http://localhost:6333
+# 容器部署时请将 QDRANT_URL 设置为服务名
+QDRANT_URL=http://mem0_store:6333
 
 OPENAI_API_KEY=sk-or-v1-
 OPENAI_BASE_URL=https://openrouter.ai/api/v1

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -162,7 +162,10 @@ def get_default_memory_config():
     openai_embedding_model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
     openai_embedding_dimension = int(os.environ.get("OPENAI_EMBEDDING_DIMENSION", "1024"))
     
-    qdrant_url = os.environ.get("QDRANT_URL", "http://localhost:6333")
+    qdrant_url = os.environ.get("QDRANT_URL")
+    if not qdrant_url:
+        # Use service name inside Docker container if DOCKER flag is set
+        qdrant_url = "http://mem0_store:6333" if os.environ.get("DOCKER") else "http://localhost:6333"
     qdrant_collection_name = os.environ.get("QDRANT_COLLECTION_NAME", "openmemory")
     
     # NEO4J配置项


### PR DESCRIPTION
## Summary
- adjust Qdrant URL default to use `mem0_store` when running in Docker unless `QDRANT_URL` is set
- document that Docker deployments must configure `QDRANT_URL`

## Testing
- `pytest openmemory` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68a262af1d048333adadd61c4754b105